### PR TITLE
Fix: disable strict mode in mkdocs build to unblock CI

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,11 +6,11 @@ nav:
     - Home: index.md
     - Architecture:
         - Overview: architecture/ARCHITECTURE.md
-        - DAG & Trust: architecture/dag_trust.md
+        # - DAG & Trust: architecture/dag_trust.md # TODO: Create this file
     - Guides:
         - Developer Journey: guides/DEVELOPER_JOURNEY.md
         - Mesh Compute: guides/mesh_compute.md
-        - Observability: guides/OBSERVABILITY_GUIDE.md
+        # - Observability: guides/OBSERVABILITY_GUIDE.md # TODO: Create this file or fix path if it exists elsewhere
     - Specs:
-        - CCL: specs/ccl_spec.md
+        # - CCL: specs/ccl_spec.md # TODO: Create this file
     - Crate Map: generated/crate_map.md 


### PR DESCRIPTION
### Summary

> Short description of what this PR does and why it matters.

### Checklist

- [ ] I ran `cargo check --workspace` with no errors
- [ ] I ran `cargo clippy --all-targets -- -D warnings`
- [ ] I ran `cargo test --workspace`
- [ ] I regenerated CLI docs (`just gen-cli-docs`) if command flags changed
- [ ] I updated relevant documentation / added new guides if applicable

### Related Issues

Closes #____ or relates to #____

### Review Tips

> Anything you'd like reviewers to focus on? 